### PR TITLE
Support recent versions of OCaml, which default to -safe-string

### DIFF
--- a/location.ml
+++ b/location.ml
@@ -43,8 +43,11 @@ let slurp chan =
     | n -> read_all (Bytes.sub buf 0 n :: chunks) in
   read_all []
 
+let slurp_string chan =
+  Bytes.to_string (slurp chan)
+
 let of_file fname =
-  source fname (slurp (open_in fname))
+  source fname (slurp_string (open_in fname))
 
 let of_string str =
   source "<input>" str


### PR DESCRIPTION
With OCaml 4.07.1, compilation fails as follows:

```
File "location.ml", line 47, characters 15-38:
Error: This expression has type bytes but an expression was expected of type
         string
```